### PR TITLE
fix wrong function signature

### DIFF
--- a/src/toeplitz.pyf
+++ b/src/toeplitz.pyf
@@ -87,7 +87,7 @@ python module toeplitz ! in
             integer(kind=4), intent(hide),depend(a) :: lda=shape(a,0)
         end subroutine cct_sl
         subroutine ctg_sl(a,x,r,m,l,lda) ! in :_toeplitz:toeplitz.f90
-            complex(kind=4) dimension(m*l,2 * l - 1),depend(m,l) :: a
+            complex(kind=4) dimension(m*m,2 * l - 1),depend(m,l) :: a
             complex(kind=4) dimension(m,l),intent(in,out) :: x
             complex(kind=4) intent(hide),dimension(m*m*(2*l+3)+m),depend(m,l) :: r
             integer(kind=4), intent(hide),depend(x) :: m=shape(x,0)


### PR DESCRIPTION
Hi, I saw in #7 that you plan to recreate the wrapper. This PR is a quick fix for the `ctg_sl` function that we need and would close #7.

We are currently in the process of writing a publication that uses `toeplitz` and want to provide source code. I'd prefer to just use your official python toeplitz package instead of having our own fork with a 1-character change ;) But I would also understand if you want to defer publishing a new version when all dimensions of all functions have been fixed.