### PR TITLE
WIP: Use meson as build tool

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,38 @@
+project('toeplitz', 'c',
+  version : '0.3.5',
+  meson_version: '>=0.64.0',
+  default_options : ['warning_level=2'],
+)
+
+add_languages('fortran')
+py_mod = import('python')
+py = py_mod.find_installation(pure: false)
+py_dep = py.dependency()
+
+incdir_numpy = run_command(py,
+  ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
+  check : true
+).stdout().strip()
+
+incdir_f2py = run_command(py,
+    ['-c', 'import os; os.chdir(".."); import numpy.f2py; print(numpy.f2py.get_include())'],
+    check : true
+).stdout().strip()
+
+toeplitz_source = custom_target('toeplitzmodule.c',
+  input : ['src/toeplitz.pyf', 'src/toeplitz.f90'],
+  output : ['toeplitzmodule.c', 'toeplitz-f2pywrappers.f'],
+  command : [py, '-m', 'numpy.f2py', '@INPUT@', '-m', 'toeplitz']
+)
+
+inc_np = include_directories(incdir_numpy, incdir_f2py)
+
+py.extension_module('toeplitz',
+  ['src/toeplitz.f90', toeplitz_source],
+  #[toeplitz_source],
+  incdir_f2py / 'fortranobject.c',
+  fortran_args: '-fallow-argument-mismatch',
+  include_directories: inc_np,
+  dependencies : py_dep,
+  install : true
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
 [build-system]
-requires = ["numpy", "setuptools"]
-build-backend = "setuptools.build_meta"
+build-backend = 'mesonpy'
+requires = ['meson-python', 'numpy']
+
+[project]
+name = "toeplitz"
+version = "0.3.5"
+authors = [
+    {name = "Tom Eulenfeld"},
+]
+description = "Python wrapper for Fortran90 toeplitz package to solve a variety of Toeplitz and circulant linear systems"
+readme = "README.rst"
+license = {text = "MIT License"}
+classifiers = [
+    'Environment :: Console',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3',
+    'Topic :: Scientific/Engineering :: Mathematics'
+]
+
+dependencies = [
+  "numpy"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/trichter/toeplitz"
+"Bug Tracker" = "https://github.com/trichter/toeplitz/issues"
+


### PR DESCRIPTION
The build tool should be switched to meson, because numpy.distutils is removed from numpy.

I managed to build an extension, but the function definitions are not correct.

```
pip install .
cd scripts
python teoplitz-runtests
```

```
  File "/home/gi48zar/dev/other/toeplitz/scripts/toeplitz-runtests", line 39, in test_cto_sl
    x2 = cto_sl(toep2, b)
         ^^^^^^^^^^^^^^^^
TypeError: toeplitz.cto_sl() missing required argument 'x' (pos 3)
```
